### PR TITLE
Update reqwest and adjust features

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,13 +81,13 @@ jobs:
         run: |
           cargo build --all-features --verbose
 
-      - name: "Build all features"
+      - name: "Build without default features"
         id: build_no_default_features
         if: ${{ always() }}
         run: |
           cargo build --no-default-features --verbose
 
-      - name: "Build all features"
+      - name: "Build reqwest with native-tls"
         id: build_native_tls
         if: ${{ always() }}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
 
       # Install Rust with clippy
       - name: "Install rust-toolchain version"
-        uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable at Apr 29, 2025, 9:23 PM GMT+2
+        uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable @ Dec 16, 2025, 6:12 PM GMT+1
         with:
           components: clippy
       # End Install Rust with clippy
@@ -53,13 +53,13 @@ jobs:
 
       # Checkout the repo
       - name: "Checkout"
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
       # End Checkout the repo
 
       # Enable Rust Caching
-      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.0
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
       # End Enable Rust Caching
 
       # Run cargo commands
@@ -80,6 +80,18 @@ jobs:
         if: ${{ always() }}
         run: |
           cargo build --all-features --verbose
+
+      - name: "Build all features"
+        id: build_no_default_features
+        if: ${{ always() }}
+        run: |
+          cargo build --no-default-features --verbose
+
+      - name: "Build all features"
+        id: build_native_tls
+        if: ${{ always() }}
+        run: |
+          cargo build --no-default-features --features reqwest/native-tls --verbose
 
       - name: "Build otp example"
         id: build_example_otp
@@ -121,7 +133,6 @@ jobs:
           cargo clippy --examples
       # End Run cargo clippy
 
-
       # Check for any previous failures, if there are stop, else continue.
       # This is useful so all test/clippy/fmt actions are done, and they can all be addressed
       - name: "Some checks failed"
@@ -130,6 +141,8 @@ jobs:
           RUN_CARGO_UPDATE: ${{ steps.run_cargo_update.outcome }}
           RUN_CARGO_TEST: ${{ steps.run_cargo_test.outcome }}
           BUILD_ALL: ${{ steps.build_all_features.outcome }}
+          BUILD_NO_DEF: ${{ steps.build_no_default_features.outcome }}
+          BUILD_NATIVE: ${{ steps.build_native_tls.outcome }}
           EXAMPLE_OTP: ${{ steps.build_example_otp.outcome }}
           EXAMPLE_OTP_ASYNC: ${{ steps.build_example_otp_async.outcome }}
           EXAMPLE_OTP_CUSTOM: ${{ steps.build_example_otp_custom.outcome }}
@@ -144,6 +157,8 @@ jobs:
           echo "|cargo update|${RUN_CARGO_UPDATE}|" >> ${GITHUB_STEP_SUMMARY}
           echo "|cargo test|${RUN_CARGO_TEST}|" >> ${GITHUB_STEP_SUMMARY}
           echo "|build all features|${BUILD_ALL}|" >> ${GITHUB_STEP_SUMMARY}
+          echo "|build no def feat|${BUILD_NO_DEF}|" >> ${GITHUB_STEP_SUMMARY}
+          echo "|build native-tls|${BUILD_NATIVE}|" >> ${GITHUB_STEP_SUMMARY}
           echo "|build example otp|${EXAMPLE_OTP}|" >> ${GITHUB_STEP_SUMMARY}
           echo "|build example otp_async|${EXAMPLE_OTP_ASYNC}|" >> ${GITHUB_STEP_SUMMARY}
           echo "|build example otp_custom|${EXAMPLE_OTP_CUSTOM}|" >> ${GITHUB_STEP_SUMMARY}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "yubico_ng"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["Mathijs van Veluw <black.dex@gmail.com>"]
-edition = "2021"
-rust-version = "1.82.0"
+edition = "2024"
+rust-version = "1.85.0"
 
 description = "Yubikey client API library"
 license = "MIT OR Apache-2.0"
@@ -23,26 +23,27 @@ include = [
 name = "yubico_ng"
 path = "src/lib.rs"
 
+[features]
+default = ["online-tokio", "reqwest/default-tls"]
+online-tokio = ["futures"]
+
 [dependencies]
 base64 = "0.22"
 futures = { version = "0.3", optional = true }
 hmac = "0.12"
 rand = "0.9"
-reqwest = { version = "0.12", features = ["blocking"], default-features = false }
+reqwest = { version = "0.13", features = ["blocking"], default-features = false }
 sha1 = "0.10"
 threadpool = "1.8"
 form_urlencoded = "1"
 
 [dev-dependencies]
-tokio = { version = ">=1.47", features = ["macros", "rt-multi-thread"], default-features = false }
+tokio = { version = ">=1.49", features = ["macros", "rt-multi-thread"], default-features = false }
 futures = "0.3"
 dotenvy = "0.15"
+# Force a minimal version for tracing which ensures reqwest/native-tls works too
+tracing = { version = ">=0.1.35" }
 
-[features]
-default = ["online-tokio", "native-tls"]
-online-tokio = ["futures"]
-native-tls = ["reqwest/native-tls"]
-rustls-tls = ["reqwest/rustls-tls"]
 
 # Linting config
 # https://doc.rust-lang.org/rustc/lints/groups.html

--- a/README.md
+++ b/README.md
@@ -188,7 +188,8 @@ The OTP is valid.
 
     #### Hightlights
 
-    In this version I removed the specific reqwest features because it would limit reqwest to those specific features.<br>
+    In this version I removed the specific `reqwest` features because it would limit `reqwest` to those specific features.<br>
+    Also updated to `reqwest` v0.13 as a minimal version. If you need to use v0.12 of `reqwest`, just keep using v0.14 of `yubico_ng`.<br>
     I default to the `default-tls` feature via the `default` feature of the crate it self, which should be fine for most use cases.
 
     If you want to use anything else besides `default-tls`, use `default-features = false`, define `reqwest` as a custom dependency and define the wanted features. This way you can use `rustls-no-provider` and use any provider supported by `reqwest`.

--- a/README.md
+++ b/README.md
@@ -179,31 +179,61 @@ The OTP is valid.
 
 ## Changelog
 
-    - 0.14.1 (2025-08-13):
-      * Exclude several files from the crate package
+- 0.15.0 (2026-01-18):
+    * Use reqwest v0.13 or higher
+    * Switched to edition 2024
+    * Set MSRV to v1.85.0 which supports edition 2024 by default
+    * Removed `native-tls` and `rustls-tls` and use `reqwest/default-tls` by default.<br>
+      All other reqwest features are disabled in this crate it self!
 
-    - 0.14.0 (2025-08-13) (not published to crates.io):
-      * Upgrade to `tokio` 1.47
-      * Bumped MSRV to v1.82.0 needed by latest packages
-      * Added more clippy/rust lints including `pedantic` and fixed found items
-      * Use only the main api server, the others are deprecated
-      * Updated GHA
-      * Added dotenvy as a dev dependency to load `.env` files
+    #### Hightlights
 
-    - 0.13.0 (2025-04-23):
-      * Upgrade to `tokio` 1.44, `rand` 0.9
-      * Renamed to yubico_ng and published crate
-      * Made edition 2024 compatible
-      * Added several clippy/rust lints and fixed those
-      * Fixed a panic if the `YK_API_HOST` was invalid
-      * Use only the main api server, the others are deprecated
-      * Run cargo fmt
-      * Updated GHA to use hashes and run/fix zizmor
+    In this version I removed the specific reqwest features because it would limit reqwest to those specific features.<br>
+    I default to the `default-tls` feature via the `default` feature of the crate it self, which should be fine for most use cases.
 
-    - 0.12.0: Upgrade to `tokio` 1.37, `reqwest` 0.12, `base64` 0.22, clippy fixes.
-    - 0.10.0: Upgrade to `tokio` 1.1 and `reqwest` 0.11
-    - 0.9.2: (Yanked) Dependencies update
-    - 0.9.1: Set HTTP Proxy (Basic-auth is optional)
-    - 0.9.0: Moving to `tokio` 0.2 and `reqwest` 0.10
-    - 0.9.0-alpha.1: Moving to `futures` 0.3.0-alpha.19
-    - 0.8: Rename the `sync` and `async` modules to `sync_verifier` and `async_verifier` to avoid the use of the `async` reserved keyword.
+    If you want to use anything else besides `default-tls`, use `default-features = false`, define `reqwest` as a custom dependency and define the wanted features. This way you can use `rustls-no-provider` and use any provider supported by `reqwest`.
+
+    ```toml
+    [dependencies]
+    yubico_ng = { version = "0.15", default-features = false, features = ["online-tokio"] }
+    reqwest = { version = "0.13.1", default-features = false, features = ["rustls-no-provider"] }
+    rustls = { version = "0.23.36", default-features = false, features = ["ring"] }
+    ```
+
+    ```rust
+    fn main() {
+        // Initialize rustls with ring so reqwest v0.13+ will work without aws-lc for example
+        rustls::crypto::ring::default_provider()
+            .install_default()
+            .expect("Failed to install rustls crypto provider for Reqwest");
+    }
+    ```
+
+- 0.14.1 (2025-08-13):
+    * Exclude several files from the crate package
+
+- 0.14.0 (2025-08-13) (not published to crates.io):
+    * Upgrade to `tokio` 1.47
+    * Bumped MSRV to v1.82.0 needed by latest packages
+    * Added more clippy/rust lints including `pedantic` and fixed found items
+    * Use only the main api server, the others are deprecated
+    * Updated GHA
+    * Added dotenvy as a dev dependency to load `.env` files
+
+- 0.13.0 (2025-04-23):
+    * Upgrade to `tokio` 1.44, `rand` 0.9
+    * Renamed to yubico_ng and published crate
+    * Made edition 2024 compatible
+    * Added several clippy/rust lints and fixed those
+    * Fixed a panic if the `YK_API_HOST` was invalid
+    * Use only the main api server, the others are deprecated
+    * Run cargo fmt
+    * Updated GHA to use hashes and run/fix zizmor
+
+- 0.12.0: Upgrade to `tokio` 1.37, `reqwest` 0.12, `base64` 0.22, clippy fixes.
+- 0.10.0: Upgrade to `tokio` 1.1 and `reqwest` 0.11
+- 0.9.2: (Yanked) Dependencies update
+- 0.9.1: Set HTTP Proxy (Basic-auth is optional)
+- 0.9.0: Moving to `tokio` 0.2 and `reqwest` 0.10
+- 0.9.0-alpha.1: Moving to `futures` 0.3.0-alpha.19
+- 0.8: Rename the `sync` and `async` modules to `sync_verifier` and `async_verifier` to avoid the use of the `async` reserved keyword.


### PR DESCRIPTION
With this commit I'm switching the default to reqwest v0.13.
I also removed the `native-tls` and `rustls-tls` features and use `reqwest/default-tls` as default.

By not forcing a specific other default than `reqwest` does, this should prevent pulling on other crates by default.
Using something else then the default is as easy as turning of the `default-features` for this crate, and pull in `reqwest` your self.

Also adjust the crate to default to the 2024 edition as it's has been available for almost a year.

If you need want to keep using `reqwest` v0.12.x, use the v0.14.x versions of this crate.
